### PR TITLE
Improve 4-month visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository contains a simple example application that demonstrates how Nasd
 ## Files
 
 - `nasdaq_sample.csv` &ndash; Sample dataset with monthly closing prices (2023&ndash;2024).
-- `visualize_nasdaq.py` &ndash; Python script that loads the sample data, resamples it to 4‑month intervals, and plots the result.
+- `visualize_nasdaq.py` &ndash; Python script that loads the sample data, resamples it to 4‑month intervals, and plots the result. Points are colored green if the price is higher than the previous 4‑month checkpoint and red if it is lower.
 
 ## Usage
 
@@ -18,6 +18,6 @@ This repository contains a simple example application that demonstrates how Nasd
    ```bash
    python visualize_nasdaq.py
    ```
-   A plot window will appear showing the monthly closing prices and the prices if trading were done only once every four months.
+   The generated plot shows the four‑month closing price series only. Each point is colored green if the price increased from the previous checkpoint or red if it decreased. The image is saved as `nasdaq_4m_plot.png` in the repository directory.
 
 This is a minimal example to illustrate the concept without fetching real data from the internet.

--- a/visualize_nasdaq.py
+++ b/visualize_nasdaq.py
@@ -9,19 +9,26 @@ def main():
     # Resample to 4-month frequency, taking the last available close
     df_4m = df.resample('4M').last()
 
-    # Plot original monthly data and 4-month resampled data
+    # Determine direction of price change compared to the previous checkpoint
+    df_4m['change'] = df_4m['close'].diff()
+    colors = df_4m['change'].apply(lambda x: 'red' if x < 0 else 'green')
+
+    # Plot only the 4-month data, indicating up/down movements
     plt.figure(figsize=(10, 6))
-    plt.plot(df.index, df['close'], label='Monthly Close', marker='o')
-    plt.plot(df_4m.index, df_4m['close'], label='4-Month Close', marker='s')
-    plt.title('NASDAQ Monthly vs. 4-Month Close')
+    plt.plot(df_4m.index, df_4m['close'], label='4-Month Close', color='blue', marker='o')
+    plt.scatter(df_4m.index, df_4m['close'], s=100, c=colors, zorder=5)
+    for idx, row in df_4m.iterrows():
+        direction = 'down' if row['change'] < 0 else 'up'
+        plt.text(idx, row['close'], direction, color=colors.loc[idx],
+                 ha='center', va='bottom')
+    plt.title('NASDAQ 4-Month Close')
     plt.xlabel('Date')
     plt.ylabel('Close Price')
-    plt.legend()
     plt.grid(True)
     plt.tight_layout()
     # Save the figure instead of displaying it to avoid GUI requirements
-    plt.savefig('nasdaq_plot.png')
-    print('Plot saved to nasdaq_plot.png')
+    plt.savefig('nasdaq_4m_plot.png')
+    print('Plot saved to nasdaq_4m_plot.png')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- visualize only 4‑month prices
- color code points red when the price drops and green when it rises
- save output as `nasdaq_4m_plot.png`
- update README with new instructions

## Testing
- `python visualize_nasdaq.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68595a84b750833187a7982f0554adbd