### PR TITLE
Add real-data stock visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains a simple example application that demonstrates how Nasd
 
 - `nasdaq_sample.csv` &ndash; Sample dataset with monthly closing prices (2023&ndash;2024).
 - `visualize_nasdaq.py` &ndash; Python script that loads the sample data, resamples it to 4‑month intervals, and plots the result. Points are colored green if the price is higher than the previous 4‑month checkpoint and red if it is lower.
+- `visualize_stock.py` &ndash; Fetches real historical data for any ticker symbol using `yfinance` and plots the monthly closing price from the start of trading.
 
 ## Usage
 
@@ -19,5 +20,11 @@ This repository contains a simple example application that demonstrates how Nasd
    python visualize_nasdaq.py
    ```
    The generated plot shows the four‑month closing price series only. Each point is colored green if the price increased from the previous checkpoint or red if it decreased. The image is saved as `nasdaq_4m_plot.png` in the repository directory.
+3. To download real monthly data for a stock and plot it, install `yfinance` and run:
+   ```bash
+   pip install yfinance
+   python visualize_stock.py AAPL  # replace AAPL with the symbol you want
+   ```
+   The script saves the figure as `<SYMBOL>_monthly_plot.png`.
 
-This is a minimal example to illustrate the concept without fetching real data from the internet.
+This is a minimal example to illustrate the concept. Fetching real data requires internet access.

--- a/visualize_stock.py
+++ b/visualize_stock.py
@@ -1,0 +1,40 @@
+import sys
+import pandas as pd
+import matplotlib.pyplot as plt
+
+try:
+    import yfinance as yf
+except ImportError:
+    print("The 'yfinance' package is required. Install it with 'pip install yfinance'.")
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python visualize_stock.py SYMBOL")
+        sys.exit(1)
+
+    symbol = sys.argv[1].upper()
+
+    # Fetch monthly data from the start of trading
+    data = yf.download(symbol, period="max", interval="1mo", auto_adjust=True)
+    if data.empty:
+        print(f"No data found for {symbol}.")
+        sys.exit(1)
+
+    close = data['Close'].dropna()
+
+    plt.figure(figsize=(10, 6))
+    plt.plot(close.index, close.values, marker='o')
+    plt.title(f"{symbol} Monthly Close")
+    plt.xlabel("Date")
+    plt.ylabel("Close Price")
+    plt.grid(True)
+    plt.tight_layout()
+    outfile = f"{symbol}_monthly_plot.png"
+    plt.savefig(outfile)
+    print(f"Plot saved to {outfile}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `visualize_stock.py` to download real monthly data with yfinance
- document new script in README

## Testing
- `python visualize_stock.py AAPL` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas matplotlib yfinance` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_685971c3269c8331ae48a6a98ba6e5ad